### PR TITLE
RecyclerViewAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ jdk:
   - oraclejdk8
 
 script:
-  ./gradlew test connectedCheck
+  # sample project uses Jack. Travis kills it, probably because of limited resources
+  ./gradlew android-mvvm:build android-mvvm:test android-mvvm:connectedCheck
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jdk:
   - oraclejdk8
 
 script:
-  ./gradlew test
+  ./gradlew test connectedCheck
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jdk:
   - oraclejdk8
 
 script:
-  ./gradlew build test
+  ./gradlew test
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - build-tools-24.0.0
     - android-24
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-23
+    - sys-img-armeabi-v7a-android-19
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jdk:
   - oraclejdk8
 
 script:
-  ./gradlew build connectedCheck test
+  ./gradlew build test
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ android:
     - build-tools-24.0.0
     - android-24
     - extra-android-m2repository
-
+    - sys-img-armeabi-v7a-android-23
 jdk:
   - oraclejdk8
 
 script:
-  ./gradlew test --continue
+  ./gradlew build connectedCheck test
 
 branches:
   except:

--- a/android-mvvm/build.gradle
+++ b/android-mvvm/build.gradle
@@ -16,6 +16,16 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    sourceSets {
+        String sharedTestDir = 'src/sharedTest/java'
+        test {
+            java.srcDir sharedTestDir
+        }
+        androidTest {
+            java.srcDir sharedTestDir
+        }
+    }
+
     dataBinding {
         enabled = true
     }

--- a/android-mvvm/build.gradle
+++ b/android-mvvm/build.gradle
@@ -28,4 +28,5 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:24.0.0'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test:runner:0.4'
+    androidTestCompile 'com.android.support.test:rules:0.4'
 }

--- a/android-mvvm/build.gradle
+++ b/android-mvvm/build.gradle
@@ -9,6 +9,10 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    dataBinding {
+        enabled = true
     }
     buildTypes {
         release {
@@ -16,13 +20,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    dataBinding {
-        enabled = true
-    }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
     compile 'io.reactivex:rxjava:1.1.7'
+    compile 'com.android.support:recyclerview-v7:24.0.0'
+    testCompile 'junit:junit:4.12'
+    androidTestCompile 'com.android.support.test:runner:0.4'
 }

--- a/android-mvvm/build.gradle
+++ b/android-mvvm/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+def isCi() {
+    return "true".equals(System.getenv('CI'))
+}
+
 android {
     compileSdkVersion 24
     buildToolsVersion "24.0.0"
@@ -11,14 +15,32 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     dataBinding {
         enabled = true
     }
+
+    dexOptions {
+        preDexLibraries = !isCi()
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+}
+
+if (isCi()) {
+    println 'Running on CI. Adding task to start emulator.'
+
+    task startEmulator << {
+        "$rootDir/gradle/start-emulator.sh".execute().waitFor()
+    }
+
+    android.testVariants.all { variant ->
+        variant.connectedInstrumentTest.dependsOn startEmulator
     }
 }
 

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
@@ -1,0 +1,78 @@
+package com.example.android_mvvm.adapters;
+
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+
+import com.example.android_mvvm.ViewModel;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import rx.subjects.BehaviorSubject;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class RecyclerViewAdapterTest {
+
+    public static final int INITIAL_COUNT = 3;
+    private BehaviorSubject<List<ViewModel>> viewModelsSource;
+    private RecyclerViewAdapter sut;
+    private int notifyCallCount;
+
+    @Before
+    public void setUp() throws Exception {
+        List<ViewModel> vms = dummyViewModels(INITIAL_COUNT);
+
+        viewModelsSource = BehaviorSubject.create(vms);
+        sut = new RecyclerViewAdapter(viewModelsSource);
+
+        notifyCallCount = 0;
+        sut.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                notifyCallCount++;
+            }
+        });
+    }
+
+    @Test
+    public void initialItemCount() throws Exception {
+        assertEquals(INITIAL_COUNT, sut.getItemCount());
+    }
+
+    @Test
+    public void itemCountOnUpdate() throws Exception {
+        viewModelsSource.onNext(dummyViewModels(10));
+
+        assertEquals(10, sut.getItemCount());
+    }
+
+    @Test
+    public void notifyIsCalledOnUpdate() throws Exception {
+        viewModelsSource.onNext(dummyViewModels(4));
+
+        assertEquals(1, notifyCallCount);
+    }
+
+    @NonNull
+    private List<ViewModel> dummyViewModels(int n) {
+        List<ViewModel> vms = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            vms.add(new TestViewModel(i));
+        }
+        return vms;
+    }
+
+    public class TestViewModel implements ViewModel {
+        int id;
+        public TestViewModel(int id) {
+            this.id = id;
+        }
+    }
+}

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
@@ -1,12 +1,18 @@
 package com.example.android_mvvm.adapters;
 
 import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
 
 import com.example.android_mvvm.ViewModel;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -16,21 +22,27 @@ import java.util.List;
 import rx.subjects.BehaviorSubject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(AndroidJUnit4.class)
 public class RecyclerViewAdapterTest {
+
+    @Rule
+    public UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
 
     public static final int INITIAL_COUNT = 3;
     private BehaviorSubject<List<ViewModel>> viewModelsSource;
     private RecyclerViewAdapter sut;
     private int notifyCallCount;
+    private ViewProvider testViewProvider;
 
     @Before
     public void setUp() throws Exception {
         List<ViewModel> vms = dummyViewModels(INITIAL_COUNT);
 
         viewModelsSource = BehaviorSubject.create(vms);
-        sut = new RecyclerViewAdapter(viewModelsSource);
+        testViewProvider = new TestViewProvider();
+        sut = new RecyclerViewAdapter(viewModelsSource, testViewProvider);
 
         notifyCallCount = 0;
         sut.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
@@ -60,6 +72,33 @@ public class RecyclerViewAdapterTest {
         assertEquals(1, notifyCallCount);
     }
 
+    @Test
+    public void itemTypeIsBasedOnViewProvider() throws Exception {
+        List<ViewModel> vms = dummyViewModels(4);
+        vms.remove(1);
+        viewModelsSource.onNext(vms);
+
+        assertEquals(0, sut.getItemViewType(0));
+        assertEquals(2, sut.getItemViewType(1));
+        assertEquals(3, sut.getItemViewType(2));
+    }
+
+
+    @Test
+    @UiThreadTest
+    public void createViewHolder() throws Exception {
+        ViewGroup parent = new LinearLayout(InstrumentationRegistry.getContext());
+        RecyclerViewAdapter.DataBindingViewHolder holder = sut.onCreateViewHolder(parent, com.example.android_mvvm.test.R.layout.layout_test);
+
+        assertNotNull(holder);
+        // Class isn't available at compile time
+        assertEquals("com.example.android_mvvm.test.databinding.LayoutTestBinding", holder.viewBinding.getClass().getName());
+    }
+
+    // TODO: Test for binding
+    // TODO: Test no subscribers after unregistering
+    // TODO: Test Errors, null
+
     @NonNull
     private List<ViewModel> dummyViewModels(int n) {
         List<ViewModel> vms = new ArrayList<>();
@@ -71,8 +110,20 @@ public class RecyclerViewAdapterTest {
 
     public class TestViewModel implements ViewModel {
         int id;
+
         public TestViewModel(int id) {
             this.id = id;
+        }
+    }
+
+    public class TestViewProvider implements ViewProvider {
+
+        @Override
+        public int getView(ViewModel vm) {
+            if (vm instanceof TestViewModel) {
+                return ((TestViewModel) vm).id;
+            }
+            return 0;
         }
     }
 }

--- a/android-mvvm/src/androidTest/res/layout/layout_test.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="vm"
+            type="com.example.android_mvvm.adapters.RecyclerViewAdapterTest.TestViewModel" />
+    </data>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+</layout>

--- a/android-mvvm/src/main/java/com/example/android_mvvm/ReadOnlyField.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/ReadOnlyField.java
@@ -2,6 +2,7 @@ package com.example.android_mvvm;
 
 import android.databinding.ObservableField;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import java.util.HashMap;
 
@@ -14,12 +15,21 @@ public class ReadOnlyField<T> extends ObservableField<T> {
     final HashMap<OnPropertyChangedCallback, Subscription> subscriptions = new HashMap<>();
 
     public ReadOnlyField(@NonNull Observable<T> source) {
-        this.source = source.doOnNext(new Action1<T>() {
-            @Override
-            public void call(T t) {
-                set(t);
-            }
-        }).share();
+        this.source = source
+                .doOnNext(new Action1<T>() {
+                    @Override
+                    public void call(T t) {
+                        set(t);
+                    }
+                })
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        Log.e("ReadOnlyField", "onError in source observable", throwable);
+                    }
+                })
+                .onErrorResumeNext(Observable.<T>empty())
+                .share();
     }
 
     /**

--- a/android-mvvm/src/main/java/com/example/android_mvvm/ViewModel.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/ViewModel.java
@@ -1,0 +1,4 @@
+package com.example.android_mvvm;
+
+public interface ViewModel {
+}

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -1,0 +1,41 @@
+package com.example.android_mvvm.adapters;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import com.example.android_mvvm.ViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import rx.Observable;
+import rx.functions.Action1;
+
+public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private List<ViewModel> latestViewModels = new ArrayList<>();
+
+    public RecyclerViewAdapter(Observable<List<ViewModel>> viewModels) {
+        viewModels.subscribe(new Action1<List<ViewModel>>() {
+            @Override
+            public void call(List<ViewModel> viewModels) {
+                latestViewModels = viewModels;
+                notifyDataSetChanged();
+            }
+        });
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        return null;
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+
+    }
+
+    @Override
+    public int getItemCount() {
+        return latestViewModels.size();
+    }
+}

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -3,35 +3,50 @@ package com.example.android_mvvm.adapters;
 import android.databinding.DataBindingUtil;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import com.example.android_mvvm.ViewModel;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import rx.Observable;
+import rx.Subscription;
 import rx.functions.Action1;
 
 public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.DataBindingViewHolder> {
     private @NonNull List<ViewModel> latestViewModels = new ArrayList<>();
     private final @NonNull ViewProvider viewProvider;
     private final @NonNull ViewModelBinder binder;
+    private final @NonNull Observable<List<ViewModel>> source;
+    private final @NonNull HashMap<RecyclerView.AdapterDataObserver, Subscription> subscriptions = new HashMap<>();
 
     public RecyclerViewAdapter(@NonNull Observable<List<ViewModel>> viewModels,
                                @NonNull ViewProvider viewProvider,
                                @NonNull ViewModelBinder viewModelBinder) {
         this.viewProvider = viewProvider;
         this.binder = viewModelBinder;
-        viewModels.subscribe(new Action1<List<ViewModel>>() {
-            @Override
-            public void call(List<ViewModel> viewModels) {
-                latestViewModels = viewModels;
-                notifyDataSetChanged();
-            }
-        });
+        source = viewModels
+                .doOnNext(new Action1<List<ViewModel>>() {
+                    @Override
+                    public void call(@Nullable List<ViewModel> viewModels) {
+                        latestViewModels = viewModels != null ? viewModels : new ArrayList<ViewModel>();
+                        notifyDataSetChanged();
+                    }
+                })
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        Log.e("RecyclerViewAdapter", "Error in source observable", throwable);
+                    }
+                })
+                .onErrorResumeNext(Observable.<List<ViewModel>>empty())
+                .share();
     }
 
     @Override
@@ -54,6 +69,21 @@ public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapte
     @Override
     public int getItemCount() {
         return latestViewModels.size();
+    }
+
+    @Override
+    public void registerAdapterDataObserver(RecyclerView.AdapterDataObserver observer) {
+        subscriptions.put(observer, source.subscribe());
+        super.registerAdapterDataObserver(observer);
+    }
+
+    @Override
+    public void unregisterAdapterDataObserver(RecyclerView.AdapterDataObserver observer) {
+        super.unregisterAdapterDataObserver(observer);
+        Subscription subscription = subscriptions.remove(observer);
+        if (subscription != null && !subscription.isUnsubscribed()) {
+            subscription.unsubscribe();
+        }
     }
 
     public static class DataBindingViewHolder extends RecyclerView.ViewHolder {

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -18,9 +18,13 @@ import rx.functions.Action1;
 public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.DataBindingViewHolder> {
     private @NonNull List<ViewModel> latestViewModels = new ArrayList<>();
     private final @NonNull ViewProvider viewProvider;
+    private final @NonNull ViewModelBinder binder;
 
-    public RecyclerViewAdapter(@NonNull Observable<List<ViewModel>> viewModels, @NonNull ViewProvider viewProvider) {
+    public RecyclerViewAdapter(@NonNull Observable<List<ViewModel>> viewModels,
+                               @NonNull ViewProvider viewProvider,
+                               @NonNull ViewModelBinder viewModelBinder) {
         this.viewProvider = viewProvider;
+        this.binder = viewModelBinder;
         viewModels.subscribe(new Action1<List<ViewModel>>() {
             @Override
             public void call(List<ViewModel> viewModels) {
@@ -43,6 +47,8 @@ public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapte
 
     @Override
     public void onBindViewHolder(DataBindingViewHolder holder, int position) {
+        binder.bind(holder.viewBinding, latestViewModels.get(position));
+        holder.viewBinding.executePendingBindings();
     }
 
     @Override

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -1,6 +1,10 @@
 package com.example.android_mvvm.adapters;
 
+import android.databinding.DataBindingUtil;
+import android.databinding.ViewDataBinding;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import com.example.android_mvvm.ViewModel;
@@ -11,10 +15,12 @@ import java.util.List;
 import rx.Observable;
 import rx.functions.Action1;
 
-public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
-    private List<ViewModel> latestViewModels = new ArrayList<>();
+public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapter.DataBindingViewHolder> {
+    private @NonNull List<ViewModel> latestViewModels = new ArrayList<>();
+    private final @NonNull ViewProvider viewProvider;
 
-    public RecyclerViewAdapter(Observable<List<ViewModel>> viewModels) {
+    public RecyclerViewAdapter(@NonNull Observable<List<ViewModel>> viewModels, @NonNull ViewProvider viewProvider) {
+        this.viewProvider = viewProvider;
         viewModels.subscribe(new Action1<List<ViewModel>>() {
             @Override
             public void call(List<ViewModel> viewModels) {
@@ -25,17 +31,31 @@ public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     }
 
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        return null;
+    public int getItemViewType(int position) {
+        return viewProvider.getView(latestViewModels.get(position));
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    public DataBindingViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        ViewDataBinding binding = DataBindingUtil.inflate(LayoutInflater.from(parent.getContext()), viewType, parent, false);
+        return new DataBindingViewHolder(binding);
+    }
 
+    @Override
+    public void onBindViewHolder(DataBindingViewHolder holder, int position) {
     }
 
     @Override
     public int getItemCount() {
         return latestViewModels.size();
+    }
+
+    public static class DataBindingViewHolder extends RecyclerView.ViewHolder {
+        final ViewDataBinding viewBinding;
+
+        public DataBindingViewHolder(ViewDataBinding viewBinding) {
+            super(viewBinding.getRoot());
+            this.viewBinding = viewBinding;
+        }
     }
 }

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -42,7 +42,7 @@ public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapte
                 .doOnError(new Action1<Throwable>() {
                     @Override
                     public void call(Throwable throwable) {
-                        Log.e("RecyclerViewAdapter", "Error in source observable", throwable);
+                        Log.e("RecyclerViewAdapter", "onError in source observable", throwable);
                     }
                 })
                 .onErrorResumeNext(Observable.<List<ViewModel>>empty())

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewModelBinder.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewModelBinder.java
@@ -1,0 +1,9 @@
+package com.example.android_mvvm.adapters;
+
+import android.databinding.ViewDataBinding;
+
+import com.example.android_mvvm.ViewModel;
+
+public interface ViewModelBinder {
+    void bind(ViewDataBinding viewDataBinding, ViewModel viewModel);
+}

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewProvider.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewProvider.java
@@ -1,0 +1,9 @@
+package com.example.android_mvvm.adapters;
+
+import android.support.annotation.IntegerRes;
+
+import com.example.android_mvvm.ViewModel;
+
+public interface ViewProvider {
+    @IntegerRes int getView(ViewModel vm);
+}

--- a/android-mvvm/src/sharedTest/java/com/example/android_mvvm/testutils/SubscriptionCounter.java
+++ b/android-mvvm/src/sharedTest/java/com/example/android_mvvm/testutils/SubscriptionCounter.java
@@ -1,0 +1,24 @@
+package com.example.android_mvvm.testutils;
+
+import rx.Observable;
+import rx.functions.Action0;
+
+public class SubscriptionCounter<T> implements Observable.Transformer<T, T> {
+    public int subscriptions;
+    public int unsubscriptions;
+
+    @Override
+    public Observable<T> call(Observable<T> tObservable) {
+        return tObservable.doOnSubscribe(new Action0() {
+            @Override
+            public void call() {
+                subscriptions++;
+            }
+        }).doOnUnsubscribe(new Action0() {
+            @Override
+            public void call() {
+                unsubscriptions++;
+            }
+        });
+    }
+}

--- a/android-mvvm/src/test/java/com/example/android_mvvm/ReadOnlyFieldTests.java
+++ b/android-mvvm/src/test/java/com/example/android_mvvm/ReadOnlyFieldTests.java
@@ -64,6 +64,20 @@ public class ReadOnlyFieldTests {
         assertEquals(1, subscriptionCounter.subscriptions);
     }
 
+    @Test
+    public void errorIsHandled() throws Exception {
+        sut.addOnPropertyChangedCallback(new TestPropertyChangedCallback());
+
+        sourceSubject.onError(new Throwable());
+
+        assertEquals(INITIAL_VALUE, sut.get());
+    }
+
+    @Test
+    public void nullIsAcceptable() throws Exception {
+        sourceSubject.onNext(null);
+    }
+
     public class TestPropertyChangedCallback extends android.databinding.Observable.OnPropertyChangedCallback {
         public int callCount;
 

--- a/gradle/start-emulator.sh
+++ b/gradle/start-emulator.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-echo no | android create avd --force -n test -t android-23 --abi armeabi-v7a
+echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
 emulator -avd test -no-skin -no-audio -no-window &
 android-wait-for-emulator
 adb shell input keyevent 82

--- a/gradle/start-emulator.sh
+++ b/gradle/start-emulator.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+echo no | android create avd --force -n test -t android-23 --abi armeabi-v7a
+emulator -avd test -no-skin -no-audio -no-window &
+android-wait-for-emulator
+adb shell input keyevent 82


### PR DESCRIPTION
Because `vm` variable isn't available to the library, a `ViewModelBinder` interface has been added.

Client apps can either define a static binder which binds vms to a single variable OR subclass the adapter to implement a default binder.

There are pending changes, so this shouldn't be merged.
Fixes #4 