### PR TITLE
Implement ViewPagerAdapter 

### DIFF
--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
@@ -85,41 +85,6 @@ public class RecyclerViewAdapterTest {
     }
 
     @Test
-    public void itemTypeIsBasedOnViewProvider() throws Exception {
-        List<ViewModel> vms = dummyViewModels(4);
-        vms.remove(1);
-        viewModelsSource.onNext(vms);
-
-        assertEquals(0, sut.getItemViewType(0));
-        assertEquals(2, sut.getItemViewType(1));
-        assertEquals(3, sut.getItemViewType(2));
-    }
-
-
-    @Test
-    @UiThreadTest
-    public void createViewHolder() throws Exception {
-        ViewGroup parent = new LinearLayout(InstrumentationRegistry.getContext());
-        RecyclerViewAdapter.DataBindingViewHolder holder = sut.onCreateViewHolder(parent, com.example.android_mvvm.test.R.layout.layout_test);
-
-        assertNotNull(holder);
-        // Class isn't available at compile time
-        assertEquals("com.example.android_mvvm.test.databinding.LayoutTestBinding", holder.viewBinding.getClass().getName());
-    }
-
-    @Test
-    @UiThreadTest
-    public void bindViewHolder() throws Exception {
-        ViewGroup view = new LinearLayout(InstrumentationRegistry.getContext());
-        TestViewDataBinding binding = new TestViewDataBinding(view);
-        sut.onBindViewHolder(new RecyclerViewAdapter.DataBindingViewHolder(binding), 0);
-
-        assertTrue(testBinder.lastBinding == binding);
-        assertTrue(testBinder.lastViewModel == viewModelsSource.getValue().get(0));
-        assertEquals(1, binding.executePendingBindingsCallCount);
-    }
-
-    @Test
     public void noSubscriptionsInitially() throws Exception {
         SubscriptionCounter<List<ViewModel>> counter = new SubscriptionCounter<>();
         Observable<List<ViewModel>> source = viewModelsSource.compose(counter);
@@ -154,8 +119,43 @@ public class RecyclerViewAdapterTest {
         assertEquals(INITIAL_COUNT, sut.getItemCount());
     }
 
+    @Test
+    public void itemTypeIsBasedOnViewProvider() throws Exception {
+        List<ViewModel> vms = dummyViewModels(4);
+        vms.remove(1);
+        viewModelsSource.onNext(vms);
+
+        assertEquals(0, sut.getItemViewType(0));
+        assertEquals(2, sut.getItemViewType(1));
+        assertEquals(3, sut.getItemViewType(2));
+    }
+
+
+    @Test
+    @UiThreadTest
+    public void createViewHolder() throws Exception {
+        ViewGroup parent = new LinearLayout(InstrumentationRegistry.getContext());
+        RecyclerViewAdapter.DataBindingViewHolder holder = sut.onCreateViewHolder(parent, com.example.android_mvvm.test.R.layout.layout_test);
+
+        assertNotNull(holder);
+        // Class isn't available at compile time
+        assertEquals("com.example.android_mvvm.test.databinding.LayoutTestBinding", holder.viewBinding.getClass().getName());
+    }
+
+    @Test
+    @UiThreadTest
+    public void bindViewHolder() throws Exception {
+        ViewGroup view = new LinearLayout(InstrumentationRegistry.getContext());
+        TestViewDataBinding binding = new TestViewDataBinding(view);
+        sut.onBindViewHolder(new RecyclerViewAdapter.DataBindingViewHolder(binding), 0);
+
+        assertTrue(testBinder.lastBinding == binding);
+        assertTrue(testBinder.lastViewModel == viewModelsSource.getValue().get(0));
+        assertEquals(1, binding.executePendingBindingsCallCount);
+    }
+
     @NonNull
-    private List<ViewModel> dummyViewModels(int n) {
+    public static List<ViewModel> dummyViewModels(int n) {
         List<ViewModel> vms = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             vms.add(new TestViewModel(i));

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
@@ -1,7 +1,6 @@
 package com.example.android_mvvm.adapters;
 
 import android.databinding.ViewDataBinding;
-import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
@@ -19,7 +18,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observable;
@@ -44,7 +42,7 @@ public class RecyclerViewAdapterTest {
 
     @Before
     public void setUp() throws Exception {
-        List<ViewModel> vms = dummyViewModels(INITIAL_COUNT);
+        List<ViewModel> vms = TestViewModel.dummyViewModels(INITIAL_COUNT);
 
         viewModelsSource = BehaviorSubject.create(vms);
         testViewProvider = new TestViewProvider();
@@ -70,14 +68,14 @@ public class RecyclerViewAdapterTest {
 
     @Test
     public void itemCountOnUpdate() throws Exception {
-        viewModelsSource.onNext(dummyViewModels(10));
+        viewModelsSource.onNext(TestViewModel.dummyViewModels(10));
 
         assertEquals(10, sut.getItemCount());
     }
 
     @Test
     public void notifyIsCalledOnUpdate() throws Exception {
-        viewModelsSource.onNext(dummyViewModels(4));
+        viewModelsSource.onNext(TestViewModel.dummyViewModels(4));
 
         assertEquals(1, notifyCallCount);
     }
@@ -119,7 +117,7 @@ public class RecyclerViewAdapterTest {
 
     @Test
     public void itemTypeIsBasedOnViewProvider() throws Exception {
-        List<ViewModel> vms = dummyViewModels(4);
+        List<ViewModel> vms = TestViewModel.dummyViewModels(4);
         vms.remove(1);
         viewModelsSource.onNext(vms);
 
@@ -163,23 +161,6 @@ public class RecyclerViewAdapterTest {
 
         assertSame(binding, testBinder.lastBinding);
         assertNull(testBinder.lastViewModel);
-    }
-
-    @NonNull
-    public static List<ViewModel> dummyViewModels(int n) {
-        List<ViewModel> vms = new ArrayList<>();
-        for (int i = 0; i < n; i++) {
-            vms.add(new TestViewModel(i));
-        }
-        return vms;
-    }
-
-    public static class TestViewModel implements ViewModel {
-        int id;
-
-        public TestViewModel(int id) {
-            this.id = id;
-        }
     }
 
     public static class TestViewProvider implements ViewProvider {
@@ -229,14 +210,4 @@ public class RecyclerViewAdapterTest {
         }
     }
 
-    public static class TestViewModelBinder implements ViewModelBinder{
-        ViewDataBinding lastBinding;
-        ViewModel lastViewModel;
-
-        @Override
-        public void bind(ViewDataBinding viewDataBinding, ViewModel viewModel) {
-            lastBinding = viewDataBinding;
-            lastViewModel = viewModel;
-        }
-    }
 }

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/RecyclerViewAdapterTest.java
@@ -25,9 +25,7 @@ import java.util.List;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class RecyclerViewAdapterTest {
@@ -147,11 +145,24 @@ public class RecyclerViewAdapterTest {
     public void bindViewHolder() throws Exception {
         ViewGroup view = new LinearLayout(InstrumentationRegistry.getContext());
         TestViewDataBinding binding = new TestViewDataBinding(view);
+
         sut.onBindViewHolder(new RecyclerViewAdapter.DataBindingViewHolder(binding), 0);
 
         assertTrue(testBinder.lastBinding == binding);
         assertTrue(testBinder.lastViewModel == viewModelsSource.getValue().get(0));
         assertEquals(1, binding.executePendingBindingsCallCount);
+    }
+
+    @Test
+    @UiThreadTest
+    public void recycleUnbindsViewModel() throws Exception {
+        View view = new View(InstrumentationRegistry.getContext());
+        TestViewDataBinding binding = new TestViewDataBinding(view);
+
+        sut.onViewRecycled(new RecyclerViewAdapter.DataBindingViewHolder(binding));
+
+        assertSame(binding, testBinder.lastBinding);
+        assertNull(testBinder.lastViewModel);
     }
 
     @NonNull

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/TestViewModel.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/TestViewModel.java
@@ -1,0 +1,25 @@
+package com.example.android_mvvm.adapters;
+
+import android.support.annotation.NonNull;
+
+import com.example.android_mvvm.ViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestViewModel implements ViewModel {
+    int id;
+
+    public TestViewModel(int id) {
+        this.id = id;
+    }
+
+    @NonNull
+    public static List<ViewModel> dummyViewModels(int n) {
+        List<ViewModel> vms = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            vms.add(new TestViewModel(i));
+        }
+        return vms;
+    }
+}

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/TestViewModelBinder.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/TestViewModelBinder.java
@@ -1,0 +1,16 @@
+package com.example.android_mvvm.adapters;
+
+import android.databinding.ViewDataBinding;
+
+import com.example.android_mvvm.ViewModel;
+
+public class TestViewModelBinder implements ViewModelBinder {
+    ViewDataBinding lastBinding;
+    ViewModel lastViewModel;
+
+    @Override
+    public void bind(ViewDataBinding viewDataBinding, ViewModel viewModel) {
+        lastBinding = viewDataBinding;
+        lastViewModel = viewModel;
+    }
+}

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
@@ -131,6 +131,21 @@ public class ViewPagerAdapterTest {
         assertTrue(testBinder.lastViewModel == viewModelsSource.getValue().get(0));
     }
 
+    @Test
+    @UiThreadTest
+    public void destroyItemUnbindsAndRemovesChildView() throws Exception {
+        ViewGroup container = new LinearLayout(InstrumentationRegistry.getContext());
+        Object pagerObject = sut.instantiateItem(container, 0);
+        View child = container.getChildAt(0);
+        ViewDataBinding binding = DataBindingUtil.bind(child);
+
+        sut.destroyItem(container, 0, pagerObject);
+
+        assertEquals(0, container.getChildCount());
+        assertTrue(testBinder.lastBinding == binding);
+        assertTrue(testBinder.lastViewModel == null);
+    }
+
     private class TestViewProvider implements ViewProvider {
 
         @Override

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
@@ -1,0 +1,105 @@
+package com.example.android_mvvm.adapters;
+
+import android.database.DataSetObserver;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.example.android_mvvm.ViewModel;
+import com.example.android_mvvm.testutils.SubscriptionCounter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import rx.Observable;
+import rx.subjects.BehaviorSubject;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class ViewPagerAdapterTest {
+
+    public static final int INITIAL_COUNT = 3;
+    private ViewPagerAdapter sut;
+    private BehaviorSubject<List<ViewModel>> viewModelsSource;
+    private SubscriptionCounter<List<ViewModel>> subscriptionCounter;
+    private RecyclerViewAdapterTest.TestViewProvider testViewProvider;
+    private RecyclerViewAdapterTest.TestViewModelBinder testBinder;
+    private int notifyCallCount;
+    private DataSetObserver defaultObserver;
+
+    @Before
+    public void setUp() throws Exception {
+        viewModelsSource = BehaviorSubject.create(RecyclerViewAdapterTest.dummyViewModels(INITIAL_COUNT));
+        testViewProvider = new RecyclerViewAdapterTest.TestViewProvider();
+        testBinder = new RecyclerViewAdapterTest.TestViewModelBinder();
+        subscriptionCounter = new SubscriptionCounter<>();
+        sut = new ViewPagerAdapter(viewModelsSource.compose(subscriptionCounter),
+                testViewProvider, testBinder);
+
+        notifyCallCount = 0;
+        defaultObserver = new DataSetObserver() {
+            @Override
+            public void onChanged() {
+                notifyCallCount++;
+            }
+        };
+        sut.registerDataSetObserver(defaultObserver);
+    }
+
+    @Test
+    public void initialItemCount() throws Exception {
+        assertEquals(INITIAL_COUNT, sut.getCount());
+    }
+
+    @Test
+    public void itemCountOnUpdate() throws Exception {
+        viewModelsSource.onNext(RecyclerViewAdapterTest.dummyViewModels(4));
+
+        assertEquals(4, sut.getCount());
+    }
+
+    @Test
+    public void notifyIsCalledOnUpdate() throws Exception {
+        viewModelsSource.onNext(RecyclerViewAdapterTest.dummyViewModels(4));
+
+        assertEquals(1, notifyCallCount);
+    }
+
+    @Test
+    public void noSubscriptionsInitially() throws Exception {
+        SubscriptionCounter<List<ViewModel>> counter = new SubscriptionCounter<>();
+        Observable<List<ViewModel>> source = viewModelsSource.compose(counter);
+
+        RecyclerViewAdapter sut = new RecyclerViewAdapter(source, testViewProvider, testBinder);
+
+        assertEquals(0, counter.subscriptions);
+    }
+
+    @Test
+    public void noSubscriptionsAfterRemovingAdapterObserver() throws Exception {
+        // defaultObserver is added in setup to measure notifyCount
+        assertEquals(1, subscriptionCounter.subscriptions);
+        assertEquals(0, subscriptionCounter.unsubscriptions);
+
+        sut.unregisterDataSetObserver(defaultObserver);
+
+        assertEquals(0, subscriptionCounter.subscriptions - subscriptionCounter.unsubscriptions);
+    }
+
+    @Test
+    public void nullListIsTreatedAsEmpty() throws Exception {
+        viewModelsSource.onNext(null);
+
+        assertEquals(0, sut.getCount());
+    }
+
+    @Test
+    public void errorIsHandled() throws Exception {
+        viewModelsSource.onError(new Throwable());
+
+        assertEquals(INITIAL_COUNT, sut.getCount());
+    }
+
+}

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
@@ -26,6 +26,7 @@ import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -144,6 +145,22 @@ public class ViewPagerAdapterTest {
         assertEquals(0, container.getChildCount());
         assertTrue(testBinder.lastBinding == binding);
         assertTrue(testBinder.lastViewModel == null);
+    }
+
+    @Test
+    @UiThreadTest
+    public void viewFromObject() throws Exception {
+        ViewGroup container1 = new LinearLayout(InstrumentationRegistry.getContext());
+        ViewGroup container2 = new LinearLayout(InstrumentationRegistry.getContext());
+        Object pagerObject1 = sut.instantiateItem(container1, 0);
+        Object pagerObject2 = sut.instantiateItem(container2, 1);
+        View child1 = container1.getChildAt(0);
+        View child2 = container2.getChildAt(0);
+
+        assertTrue(sut.isViewFromObject(child1, pagerObject1));
+        assertFalse(sut.isViewFromObject(child1, pagerObject2));
+        assertTrue(sut.isViewFromObject(child2, pagerObject2));
+        assertFalse(sut.isViewFromObject(child2, pagerObject1));
     }
 
     private class TestViewProvider implements ViewProvider {

--- a/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
+++ b/android-mvvm/src/androidTest/java/com/example/android_mvvm/adapters/ViewPagerAdapterTest.java
@@ -39,15 +39,15 @@ public class ViewPagerAdapterTest {
     private BehaviorSubject<List<ViewModel>> viewModelsSource;
     private SubscriptionCounter<List<ViewModel>> subscriptionCounter;
     private TestViewProvider testViewProvider;
-    private RecyclerViewAdapterTest.TestViewModelBinder testBinder;
+    private TestViewModelBinder testBinder;
     private int notifyCallCount;
     private DataSetObserver defaultObserver;
 
     @Before
     public void setUp() throws Exception {
-        viewModelsSource = BehaviorSubject.create(RecyclerViewAdapterTest.dummyViewModels(INITIAL_COUNT));
+        viewModelsSource = BehaviorSubject.create(TestViewModel.dummyViewModels(INITIAL_COUNT));
         testViewProvider = new TestViewProvider();
-        testBinder = new RecyclerViewAdapterTest.TestViewModelBinder();
+        testBinder = new TestViewModelBinder();
         subscriptionCounter = new SubscriptionCounter<>();
         sut = new ViewPagerAdapter(viewModelsSource.compose(subscriptionCounter),
                 testViewProvider, testBinder);
@@ -69,14 +69,14 @@ public class ViewPagerAdapterTest {
 
     @Test
     public void itemCountOnUpdate() throws Exception {
-        viewModelsSource.onNext(RecyclerViewAdapterTest.dummyViewModels(4));
+        viewModelsSource.onNext(TestViewModel.dummyViewModels(4));
 
         assertEquals(4, sut.getCount());
     }
 
     @Test
     public void notifyIsCalledOnUpdate() throws Exception {
-        viewModelsSource.onNext(RecyclerViewAdapterTest.dummyViewModels(4));
+        viewModelsSource.onNext(TestViewModel.dummyViewModels(4));
 
         assertEquals(1, notifyCallCount);
     }
@@ -86,7 +86,7 @@ public class ViewPagerAdapterTest {
         SubscriptionCounter<List<ViewModel>> counter = new SubscriptionCounter<>();
         Observable<List<ViewModel>> source = viewModelsSource.compose(counter);
 
-        RecyclerViewAdapter sut = new RecyclerViewAdapter(source, testViewProvider, testBinder);
+        ViewPagerAdapter sut = new ViewPagerAdapter(source, testViewProvider, testBinder);
 
         assertEquals(0, counter.subscriptions);
     }

--- a/android-mvvm/src/androidTest/res/layout/layout_test.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_test.xml
@@ -3,7 +3,7 @@
     <data>
         <variable
             name="vm"
-            type="com.example.android_mvvm.adapters.RecyclerViewAdapterTest.TestViewModel" />
+            type="com.example.android_mvvm.adapters.TestViewModel" />
     </data>
     <TextView
         android:layout_width="wrap_content"

--- a/android-mvvm/src/main/java/com/example/android_mvvm/FieldUtils.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/FieldUtils.java
@@ -9,7 +9,7 @@ import rx.Subscriber;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
 
-public class BindingUtils {
+public class FieldUtils {
     @NonNull
     public static <T> Observable<T> toObservable(@NonNull final ObservableField<T> field) {
         return Observable.create(new Observable.OnSubscribe<T>() {

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/Connectable.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/Connectable.java
@@ -1,0 +1,7 @@
+package com.example.android_mvvm.adapters;
+
+import rx.Subscription;
+
+public interface Connectable {
+    Subscription connect();
+}

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/RecyclerViewAdapter.java
@@ -67,6 +67,11 @@ public class RecyclerViewAdapter extends RecyclerView.Adapter<RecyclerViewAdapte
     }
 
     @Override
+    public void onViewRecycled(DataBindingViewHolder holder) {
+        binder.bind(holder.viewBinding, null);
+    }
+
+    @Override
     public int getItemCount() {
         return latestViewModels.size();
     }

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
@@ -86,12 +86,14 @@ public class ViewPagerAdapter extends PagerAdapter {
                 false);
         binder.bind(binding, vm);
         container.addView(binding.getRoot());
-        return vm;
+        return binding;
     }
 
     @Override
     public void destroyItem(ViewGroup container, int position, Object object) {
-        super.destroyItem(container, position, object);
+        ViewDataBinding binding = (ViewDataBinding) object;
+        binder.bind(binding, null);
+        container.removeView(binding.getRoot());
     }
 
     @Override

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
@@ -1,0 +1,90 @@
+package com.example.android_mvvm.adapters;
+
+import android.database.DataSetObserver;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.view.PagerAdapter;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.android_mvvm.ViewModel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import rx.Observable;
+import rx.Subscription;
+import rx.functions.Action1;
+
+public class ViewPagerAdapter extends PagerAdapter {
+
+    @NonNull
+    private List<ViewModel> latestViewModels = new ArrayList<>();
+
+    @NonNull
+    private final Observable<List<ViewModel>> source;
+
+    @NonNull
+    private final HashMap<DataSetObserver, Subscription> subscriptions = new HashMap<>();
+
+    public ViewPagerAdapter(Observable<List<ViewModel>> viewModels, ViewProvider viewProvider, ViewModelBinder binder) {
+        source = viewModels
+                .doOnNext(new Action1<List<ViewModel>>() {
+                    @Override
+                    public void call(@Nullable List<ViewModel> viewModels) {
+                        latestViewModels = (viewModels != null) ? viewModels : new ArrayList<ViewModel>();
+                        notifyDataSetChanged();
+                    }
+                })
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        Log.e("ViewPagerAdapter", "Error in source observable", throwable);
+                    }
+                })
+                .onErrorResumeNext(Observable.<List<ViewModel>>empty())
+                .share();
+    }
+
+    @Override
+    public void registerDataSetObserver(DataSetObserver observer) {
+        subscriptions.put(observer, source.subscribe());
+        super.registerDataSetObserver(observer);
+    }
+
+    @Override
+    public void unregisterDataSetObserver(DataSetObserver observer) {
+        super.unregisterDataSetObserver(observer);
+        Subscription subscription = subscriptions.remove(observer);
+        if (subscription != null && !subscription.isUnsubscribed()) {
+            subscription.unsubscribe();
+        }
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
+        return super.instantiateItem(container, position);
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        super.destroyItem(container, position, object);
+    }
+
+    @Override
+    public int getItemPosition(Object object) {
+        return super.getItemPosition(object);
+    }
+
+    @Override
+    public int getCount() {
+        return latestViewModels.size();
+    }
+
+    @Override
+    public boolean isViewFromObject(View view, Object object) {
+        return false;
+    }
+}

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
@@ -108,6 +108,6 @@ public class ViewPagerAdapter extends PagerAdapter {
 
     @Override
     public boolean isViewFromObject(View view, Object object) {
-        return false;
+        return ((ViewDataBinding)object).getRoot() == view;
     }
 }

--- a/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/adapters/ViewPagerAdapter.java
@@ -1,6 +1,5 @@
 package com.example.android_mvvm.adapters;
 
-import android.database.DataSetObserver;
 import android.databinding.DataBindingUtil;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.NonNull;
@@ -14,13 +13,11 @@ import android.view.ViewGroup;
 import com.example.android_mvvm.ViewModel;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import rx.Observable;
 import rx.Subscription;
 import rx.functions.Action1;
-import rx.observables.ConnectableObservable;
 
 public class ViewPagerAdapter extends PagerAdapter implements Connectable {
 
@@ -28,7 +25,7 @@ public class ViewPagerAdapter extends PagerAdapter implements Connectable {
     private List<ViewModel> latestViewModels = new ArrayList<>();
 
     @NonNull
-    private final ConnectableObservable<List<ViewModel>> source;
+    private final Observable<List<ViewModel>> source;
 
     @NonNull
     private final ViewProvider viewProvider;
@@ -52,7 +49,7 @@ public class ViewPagerAdapter extends PagerAdapter implements Connectable {
                     }
                 })
                 .onErrorResumeNext(Observable.<List<ViewModel>>empty())
-                .replay(1);
+                .share();
         this.viewProvider = viewProvider;
         this.binder = binder;
     }
@@ -95,6 +92,6 @@ public class ViewPagerAdapter extends PagerAdapter implements Connectable {
 
     @Override
     public Subscription connect() {
-        return source.connect();
+        return source.subscribe();
     }
 }

--- a/android-mvvm/src/main/java/com/example/android_mvvm/utils/BindingUtils.java
+++ b/android-mvvm/src/main/java/com/example/android_mvvm/utils/BindingUtils.java
@@ -1,0 +1,27 @@
+package com.example.android_mvvm.utils;
+
+import android.databinding.BindingAdapter;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+
+import com.example.android_mvvm.R;
+import com.example.android_mvvm.adapters.Connectable;
+
+import rx.Subscription;
+
+public class BindingUtils {
+    @BindingAdapter("adapter")
+    public static void bindAdapter(ViewPager viewPager, PagerAdapter adapter) {
+        PagerAdapter oldAdapter = viewPager.getAdapter();
+        if (oldAdapter != null && oldAdapter instanceof Connectable) {
+            Subscription subscription = (Subscription) viewPager.getTag(R.integer.tag_subscription);
+            if (subscription != null && !subscription.isUnsubscribed()) {
+                subscription.unsubscribe();
+            }
+        }
+        if (adapter != null && adapter instanceof Connectable) {
+            viewPager.setTag(R.integer.tag_subscription, ((Connectable) adapter).connect());
+        }
+        viewPager.setAdapter(adapter);
+    }
+}

--- a/android-mvvm/src/main/res/values/integers.xml
+++ b/android-mvvm/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="tag_subscription">1</integer>
+</resources>

--- a/android-mvvm/src/test/java/com/example/android_mvvm/FieldUtilsTest.java
+++ b/android-mvvm/src/test/java/com/example/android_mvvm/FieldUtilsTest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 import rx.Observable;
 import rx.observers.TestSubscriber;
 
-import static com.example.android_mvvm.BindingUtils.toObservable;
+import static com.example.android_mvvm.FieldUtils.toObservable;
 
-public class BindingUtilsTest {
+public class FieldUtilsTest {
 
     public static final int INITIAL_VALUE = 4;
     private Observable<Integer> sut;

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".recyclerview.ItemListActivity"></activity>
+        <activity android:name=".adapters.ItemListActivity"></activity>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/example/android_mvvm/sample/BindingAdapters.java
+++ b/sample/src/main/java/com/example/android_mvvm/sample/BindingAdapters.java
@@ -3,10 +3,13 @@ package com.example.android_mvvm.sample;
 import android.databinding.BindingAdapter;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.LayoutRes;
+import android.support.v4.view.ViewPager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
 import com.example.android_mvvm.ViewModel;
+import com.example.android_mvvm.utils.BindingUtils;
+import com.example.android_mvvm.adapters.ViewPagerAdapter;
 import com.example.android_mvvm.sample.BR;
 import com.example.android_mvvm.adapters.RecyclerViewAdapter;
 import com.example.android_mvvm.adapters.ViewModelBinder;
@@ -19,16 +22,18 @@ import rx.Observable;
 @SuppressWarnings("unused")
 public class BindingAdapters {
 
+    private static final ViewModelBinder defaultBinder = new ViewModelBinder() {
+        @Override
+        public void bind(ViewDataBinding viewDataBinding, ViewModel viewModel) {
+            viewDataBinding.setVariable(BR.vm, viewModel);
+        }
+    };
+
     @BindingAdapter({"items", "view_provider"})
     public static void bindRecyclerViewAdapter(RecyclerView recyclerView, Observable<List<ViewModel>> items, ViewProvider viewProvider) {
         RecyclerViewAdapter adapter = null;
         if (items != null && viewProvider != null) {
-            adapter = new RecyclerViewAdapter(items, viewProvider, new ViewModelBinder() {
-                @Override
-                public void bind(ViewDataBinding viewDataBinding, ViewModel viewModel) {
-                    viewDataBinding.setVariable(BR.vm, viewModel);
-                }
-            });
+            adapter = new RecyclerViewAdapter(items, viewProvider, defaultBinder);
         }
         recyclerView.setAdapter(adapter);
     }
@@ -47,5 +52,14 @@ public class BindingAdapters {
     public static void bindLayoutManager(RecyclerView recyclerView, boolean vertical) {
         int orientation = vertical ? RecyclerView.VERTICAL : RecyclerView.HORIZONTAL;
         recyclerView.setLayoutManager(new LinearLayoutManager(recyclerView.getContext(), orientation, false));
+    }
+
+    @BindingAdapter({"items", "view_provider"})
+    public static void bindViewPagerAdapter(ViewPager viewPager, Observable<List<ViewModel>> items, ViewProvider viewProvider) {
+        ViewPagerAdapter adapter = null;
+        if (items != null && viewProvider != null) {
+            adapter = new ViewPagerAdapter(items, viewProvider, defaultBinder);
+        }
+        BindingUtils.bindAdapter(viewPager, adapter);
     }
 }

--- a/sample/src/main/java/com/example/android_mvvm/sample/MainActivity.java
+++ b/sample/src/main/java/com/example/android_mvvm/sample/MainActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 
-import com.example.android_mvvm.sample.recyclerview.ItemListActivity;
+import com.example.android_mvvm.sample.adapters.ItemListActivity;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/sample/src/main/java/com/example/android_mvvm/sample/adapters/ItemListActivity.java
+++ b/sample/src/main/java/com/example/android_mvvm/sample/adapters/ItemListActivity.java
@@ -1,4 +1,4 @@
-package com.example.android_mvvm.sample.recyclerview;
+package com.example.android_mvvm.sample.adapters;
 
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
@@ -16,5 +16,6 @@ public class ItemListActivity extends AppCompatActivity {
         viewModel = new ItemListViewModel();
         ActivityItemListBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_item_list);
         binding.setVm(viewModel);
+        setTitle("Adapters Demo");
     }
 }

--- a/sample/src/main/java/com/example/android_mvvm/sample/adapters/ItemListViewModel.java
+++ b/sample/src/main/java/com/example/android_mvvm/sample/adapters/ItemListViewModel.java
@@ -1,4 +1,4 @@
-package com.example.android_mvvm.sample.recyclerview;
+package com.example.android_mvvm.sample.adapters;
 
 import com.example.android_mvvm.ViewModel;
 import com.example.android_mvvm.sample.Item;

--- a/sample/src/main/res/layout/activity_item_list.xml
+++ b/sample/src/main/res/layout/activity_item_list.xml
@@ -8,7 +8,7 @@
 
         <variable
             name="vm"
-            type="com.example.android_mvvm.sample.recyclerview.ItemListViewModel" />
+            type="com.example.android_mvvm.sample.adapters.ItemListViewModel" />
 
         <import type="com.example.android_mvvm.sample.ViewProviders" />
     </data>
@@ -21,7 +21,13 @@
         android:paddingLeft="@dimen/activity_horizontal_margin"
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingTop="@dimen/activity_vertical_margin"
-        tools:context=".recyclerview.ItemListActivity">
+        tools:context=".adapters.ItemListActivity"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="RecyclerView with dynamic views" />
 
         <!--Example with dynamic views-->
         <android.support.v7.widget.RecyclerView
@@ -32,6 +38,11 @@
             bind:layout_vertical="@{true}"
             bind:view_provider="@{ViewProviders.itemListing}" />
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="RecyclerView with static views" />
+
         <!--Example With Static Views-->
         <android.support.v7.widget.RecyclerView
             android:layout_width="match_parent"
@@ -40,6 +51,11 @@
             bind:items="@{vm.itemVms}"
             bind:layout_vertical="@{true}"
             bind:view_provider="@{@layout/row_item_without_image}" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="ViewPager with dynamic views" />
 
         <!--ViewPager with Dynamic views-->
         <android.support.v4.view.ViewPager

--- a/sample/src/main/res/layout/activity_item_list.xml
+++ b/sample/src/main/res/layout/activity_item_list.xml
@@ -16,35 +16,38 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        tools:context=".recyclerview.ItemListActivity">
 
         <!--Example with dynamic views-->
         <android.support.v7.widget.RecyclerView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:paddingBottom="@dimen/activity_vertical_margin"
-            android:paddingLeft="@dimen/activity_horizontal_margin"
-            android:paddingRight="@dimen/activity_horizontal_margin"
-            android:paddingTop="@dimen/activity_vertical_margin"
             bind:items="@{vm.itemVms}"
             bind:layout_vertical="@{true}"
-            bind:view_provider="@{ViewProviders.itemListing}"
-            tools:context=".recyclerview.ItemListActivity" />
+            bind:view_provider="@{ViewProviders.itemListing}" />
 
         <!--Example With Static Views-->
         <android.support.v7.widget.RecyclerView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:paddingBottom="@dimen/activity_vertical_margin"
-            android:paddingLeft="@dimen/activity_horizontal_margin"
-            android:paddingRight="@dimen/activity_horizontal_margin"
-            android:paddingTop="@dimen/activity_vertical_margin"
             bind:items="@{vm.itemVms}"
             bind:layout_vertical="@{true}"
-            bind:view_provider="@{@layout/row_item_without_image}"
-            tools:context=".recyclerview.ItemListActivity" />
+            bind:view_provider="@{@layout/row_item_without_image}" />
+
+        <!--ViewPager with Dynamic views-->
+        <android.support.v4.view.ViewPager
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            bind:items="@{vm.itemVms}"
+            bind:view_provider="@{ViewProviders.itemListing}" />
 
     </LinearLayout>
 </layout>


### PR DESCRIPTION
Unlike RecyclerViewAdapter, PagerAdapter doesn't provide events when ViewPager is attached. Hence, it needs to be activated and deactivated. The method to activate is called `connect` which returns a `Subscription`.

For data binding, a utility method `bindAdapter(ViewPager, PagerAdapter)` has been provided which handles the connection and disconnection.

## Another Possible Approach
There is a common pattern between ViewPagerAdapter and RecyclerViewAdapter, which will likely be present in other adapters to come. 
Discussions about this: #13 