### PR TITLE
Support for binding list of ViewModel subclasses

### DIFF
--- a/android-mvvm/src/androidTest/java/com/manaschaudhari/android_mvvm/BindingTestViewModel.java
+++ b/android-mvvm/src/androidTest/java/com/manaschaudhari/android_mvvm/BindingTestViewModel.java
@@ -17,6 +17,7 @@
 package com.manaschaudhari.android_mvvm;
 
 import com.manaschaudhari.android_mvvm.adapters.TestViewModel;
+import com.manaschaudhari.android_mvvm.adapters.ViewProvider;
 
 import java.util.List;
 
@@ -27,4 +28,6 @@ public class BindingTestViewModel implements ViewModel {
     public List<ViewModel> mixedList;
     public Observable<List<ViewModel>> observableMixedList;
     public Observable<List<TestViewModel>> observableSubclassMixedList;
+
+    public ViewProvider viewProvider;
 }

--- a/android-mvvm/src/androidTest/java/com/manaschaudhari/android_mvvm/BindingTestViewModel.java
+++ b/android-mvvm/src/androidTest/java/com/manaschaudhari/android_mvvm/BindingTestViewModel.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Manas Chaudhari
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.manaschaudhari.android_mvvm;
+
+import com.manaschaudhari.android_mvvm.adapters.TestViewModel;
+
+import java.util.List;
+
+import rx.Observable;
+
+public class BindingTestViewModel implements ViewModel {
+    public List<TestViewModel> subclassList;
+    public List<ViewModel> mixedList;
+    public Observable<List<ViewModel>> observableMixedList;
+    public Observable<List<TestViewModel>> observableSubclassMixedList;
+}

--- a/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
@@ -11,6 +11,8 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
+        <!-- RecyclerView -->
+
         <android.support.v7.widget.RecyclerView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -30,6 +32,38 @@
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.observableSubclassMixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:layout_vertical="@{true}" />
+
+
+        <!-- View Pager -->
+
+        <android.support.v4.view.ViewPager
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.mixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v4.view.ViewPager
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.subclassList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v4.view.ViewPager
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.observableMixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v4.view.ViewPager
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             bind:items="@{vm.observableSubclassMixedList}"

--- a/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
@@ -14,64 +14,44 @@
         <!-- RecyclerView -->
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.mixedList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.subclassList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.observableMixedList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.observableSubclassMixedList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.observableSubclassMixedList}"
             bind:view_provider="@{vm.viewProvider}" />
 
         <android.support.v7.widget.RecyclerView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:layout_vertical="@{true}" />
 
 
         <!-- View Pager -->
 
         <android.support.v4.view.ViewPager
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.mixedList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v4.view.ViewPager
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.subclassList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v4.view.ViewPager
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.observableMixedList}"
             bind:view_provider="@{@layout/layout_test}" />
 
         <android.support.v4.view.ViewPager
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             bind:items="@{vm.observableSubclassMixedList}"
             bind:view_provider="@{@layout/layout_test}" />
     </LinearLayout>

--- a/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
@@ -40,6 +40,12 @@
         <android.support.v7.widget.RecyclerView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            bind:items="@{vm.observableSubclassMixedList}"
+            bind:view_provider="@{vm.viewProvider}" />
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             bind:layout_vertical="@{true}" />
 
 

--- a/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
+++ b/android-mvvm/src/androidTest/res/layout/layout_binding_tests.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:bind="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="vm"
+            type="com.manaschaudhari.android_mvvm.BindingTestViewModel" />
+    </data>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.mixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.subclassList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.observableMixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            bind:items="@{vm.observableSubclassMixedList}"
+            bind:view_provider="@{@layout/layout_test}" />
+    </LinearLayout>
+</layout>

--- a/android-mvvm/src/main/java/com/manaschaudhari/android_mvvm/utils/BindingUtils.java
+++ b/android-mvvm/src/main/java/com/manaschaudhari/android_mvvm/utils/BindingUtils.java
@@ -125,7 +125,7 @@ public class BindingUtils {
 
     @BindingConversion
     @Nullable
-    public static <T extends ViewModel> Observable<List<ViewModel>> toObservable(@Nullable List<T> specificList) {
+    public static <T extends ViewModel> Observable<List<ViewModel>> toListObservable(@Nullable List<T> specificList) {
         return specificList == null ? null :
                 Observable.just((List<ViewModel>)new ArrayList<ViewModel>(specificList));
     }

--- a/android-mvvm/src/main/java/com/manaschaudhari/android_mvvm/utils/BindingUtils.java
+++ b/android-mvvm/src/main/java/com/manaschaudhari/android_mvvm/utils/BindingUtils.java
@@ -34,10 +34,12 @@ import com.manaschaudhari.android_mvvm.adapters.ViewModelBinder;
 import com.manaschaudhari.android_mvvm.adapters.ViewPagerAdapter;
 import com.manaschaudhari.android_mvvm.adapters.ViewProvider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import rx.Observable;
 import rx.Subscription;
+import rx.functions.Func1;
 
 @SuppressWarnings("unused")
 public class BindingUtils {
@@ -108,6 +110,24 @@ public class BindingUtils {
                 return layoutId;
             }
         };
+    }
+
+    @BindingConversion
+    @Nullable
+    public static <T extends ViewModel> Observable<List<ViewModel>> toGenericList(@Nullable Observable<List<T>> specificList) {
+        return specificList == null ? null : specificList.map(new Func1<List<T>, List<ViewModel>>() {
+            @Override
+            public List<ViewModel> call(List<T> ts) {
+                return new ArrayList<ViewModel>(ts);
+            }
+        });
+    }
+
+    @BindingConversion
+    @Nullable
+    public static <T extends ViewModel> Observable<List<ViewModel>> toObservable(@Nullable List<T> specificList) {
+        return specificList == null ? null :
+                Observable.just((List<ViewModel>)new ArrayList<ViewModel>(specificList));
     }
 
     // Extra Utilities

--- a/sample/src/main/java/com/manaschaudhari/android_mvvm/sample/adapters/ItemListViewModel.java
+++ b/sample/src/main/java/com/manaschaudhari/android_mvvm/sample/adapters/ItemListViewModel.java
@@ -31,7 +31,7 @@ import rx.functions.Func1;
 import rx.subjects.BehaviorSubject;
 
 public class ItemListViewModel implements ViewModel {
-    public final Observable<List<ViewModel>> itemVms;
+    public final Observable<List<ItemViewModel>> itemVms;
 
     /**
      * Static non-terminating source will ensure that any non-closed subscription results in a memory leak
@@ -48,10 +48,10 @@ public class ItemListViewModel implements ViewModel {
     }
 
     public ItemListViewModel(@NonNull final MessageHelper messageHelper, @NonNull final Navigator navigator) {
-        this.itemVms = itemsSource.map(new Func1<List<Item>, List<ViewModel>>() {
+        this.itemVms = itemsSource.map(new Func1<List<Item>, List<ItemViewModel>>() {
             @Override
-            public List<ViewModel> call(List<Item> items) {
-                List<ViewModel> vms = new ArrayList<>();
+            public List<ItemViewModel> call(List<Item> items) {
+                List<ItemViewModel> vms = new ArrayList<>();
                 for (Item item : items) {
                     vms.add(new ItemViewModel(item, messageHelper, navigator));
                 }


### PR DESCRIPTION
Fixes #32 

Added a layout for maintaining tests for all variations of `BindingAdapter`s and `BindingConversion`s provided by the library